### PR TITLE
Update docstrings

### DIFF
--- a/entanglement/interface.py
+++ b/entanglement/interface.py
@@ -213,14 +213,17 @@ class Synchronizable( metaclass = SynchronizableMeta):
 
     '''Represents a class that can be synchronized
 
-A *Synchronizable* can be synchronized between two     Entanglement `SyncManager`\ s.  Objects are synchronized by calling
-the :meth:`entanglement.network.SyncManager.synchronize` method on a SyncManager.  Synchronizables have one
-or more sync_properties.  The `sync_properties <sync_property>` are packaged up into
-a serialized representation by the to_sync method and
-reconstituted into an object by the `sync_construct`, `sync_receive`
-and `sync_receive_constructed` methods.  Objects may have primary keys set in the `sync_primary_keys` attribute.  Objects with the
-same sync_primary_keys may be coalesced during transmission; only
-the latest synchronized version will be sent.
+    A *Synchronizable* can be synchronized between two Entanglement
+    `SyncManager`s.  Objects are synchronized by calling the
+    :meth:`entanglement.network.SyncManager.synchronize` method on a
+    SyncManager.  Synchronizables have one or more sync_properties.
+    The `sync_properties <sync_property>` are packaged up into a
+    serialized representation by the to_sync method and reconstituted
+    into an object by the `sync_construct`, `sync_receive` and
+    `sync_receive_constructed` methods.  Objects may have primary keys
+    set in the `sync_primary_keys` attribute.  Objects with the same
+    sync_primary_keys may be coalesced during transmission; only the
+    latest synchronized version will be sent.
 
     '''
     

--- a/javascript/filter.js
+++ b/javascript/filter.js
@@ -203,14 +203,20 @@ function mapFilter(options) {
 /**
    * Indicate a relationship between two :class:`Synchronizables`.
    * The *local* class is the one that in a database would have a
-   * foreign key constraint; the one with a higher sync_priority.
-   * This supports one-to-one and one-to-many relationships.
+   * foreign key constraint; the one with a higher sync_priority
+   * (where higher sync_priority means that the local class is synced
+   * after the remote).  This supports one-to-one and one-to-many
+   * relationships.
    *
    * :param local: The local class
    * :param options: A set of options for the relationship:
    *
    * use_list
-   *    Defaults to true; if true, then the remote side of the relationship is a list (one-to-many).  If "object" then an object is used and "object_key" contains the key in the local object to use to populate the object stored in remote_prop in the remote.
+   *    Defaults to true; if true, then the remote side of the
+   *    relationship is a list (one-to-many).  If "object" then an
+   *    object is used and "object_key" contains the key in the local
+   *    object to use to populate the object stored in remote_prop in
+   *    the remote.
    *
    * remote
    *    Class that is the other side of the relationship


### PR DESCRIPTION
The '\ ' in the one string was breaking the test suite on python3.11