### PR TITLE
Consistently use info2 as Integer

### DIFF
--- a/tests/websocket/testPersistence.js
+++ b/tests/websocket/testPersistence.js
@@ -105,7 +105,7 @@ async function testCreates(owner) {
         throw new TypeError(`${result} is not a TableInherits`);
     }
     assert.equal(ti.info, result.info);
-    result.info2 = "barbaz";
+    result.info2 = 9091;
     let result2 = await result.syncUpdate(sm);
     assert.equal(result, result2);
     await testDelete(result);
@@ -158,7 +158,7 @@ async function testBreakingTransition(owner, phase, trans_obj) {
     // Now that we have an object, bring it back into transition, have
     // the other side break the transition, and confirm our changes
     // revert
-    trans_obj.info2 = "wrong";
+    trans_obj.info2 = -1;
     let promise = sm.perform_transition(trans_obj);
     let oldSyncReceive = trans_obj.syncReceive;
     trans_obj.syncReceive = async function(...rest) {

--- a/tests/websocket/test_websocket.py
+++ b/tests/websocket/test_websocket.py
@@ -62,7 +62,7 @@ class TableInherits(TableBase):
                 ForeignKey(TableBase.id, ondelete = "cascade"),
                 primary_key = True)
     info = Column(String(30))
-    info2 = Column(String(30))
+    info2 = Column(Integer)
     __mapper_args__ = {'polymorphic_identity': "inherits"}
 
 class TableTransition(TableInherits, SqlTransitionTrackerMixin):
@@ -277,7 +277,7 @@ def test_sync_receive_registry(layout_module):
     future = run_js_test('testSyncReceiveRegistry.js')
     def send_obj(connected_future):
         ti = TableInherits()
-        ti.info = 90
+        ti.info = '90'
         ti.info2 = 20
         layout.server.session.add(ti)
         layout.server.session.commit()
@@ -293,8 +293,8 @@ def test_sync_orig(layout_module):
     ti = TableInherits()
     def send_obj(connected_future):
         nonlocal ti
+        ti.info = '99'
         ti.info2 = 19
-        ti.info = 99
         layout.server.session.add(ti)
         layout.server.session.commit()
     loop = layout.loop
@@ -313,7 +313,7 @@ def test_sync_events(layout_module):
     future = run_js_test('testSyncEvents.js')
     def send_obj(connected_future):
         ti = TableInherits()
-        ti.info = 90
+        ti.info = '90'
         ti.info2 = 20
         layout.server.session.add(ti)
         layout.server.session.commit()
@@ -327,7 +327,7 @@ def test_schemas(loop, layout_module):
     future = run_js_test("testSchemas.js")
     def send_obj(connected_future):
         ti = TableInherits()
-        ti.info = 90
+        ti.info = '90'
         ti.info2 = 20
         layout.server.session.add(ti)
         layout.server.session.commit()


### PR DESCRIPTION
The previous tests used a mixture of String and Integer.  I changed info2 to be Integer so there would be two different types.  It might be worth investigating why the tests don't always detect type errors, but I didn't do that investigation.