### PR TITLE
Convert to support sqlalchemy 2.0

### DIFF
--- a/entanglement/sql/base.py
+++ b/entanglement/sql/base.py
@@ -93,7 +93,7 @@ class SqlSyncSession(sqlalchemy.orm.Session):
     def _handle_dirty(session, internal = None, instances = None, expunge_nonlocal = False):
         serial_insert = Serial.__table__.insert().values(timestamp = datetime.datetime.now())
         serial_flushed = False
-        owner_stmt = select([SyncOwner.id]) \
+        owner_stmt = select(SyncOwner.id) \
             .where(SyncOwner.dest_hash == None)
         local_owner = None
         for inst in session.new | session.dirty:

--- a/entanglement/sql/base.py
+++ b/entanglement/sql/base.py
@@ -408,8 +408,7 @@ class SqlSyncRegistry(interface.SyncRegistry):
         object.sync_owner
 
 
-
-_internal_base = sqlalchemy.ext.declarative.declarative_base()
+_internal_base = sqlalchemy.orm.declarative_base()
 
 class Serial(_internal_base):
     "Keep track of serial numbers.  A sequence would be better, but sqlite can't do them"
@@ -810,7 +809,7 @@ def sql_sync_declarative_base(*args, registry = None,
         class DeclarativeBase(SqlSynchronizable, cls): pass
         cls = DeclarativeBase
     else: cls = SqlSynchronizable
-    base =  sqlalchemy.ext.declarative.declarative_base(cls = cls, metaclass = SqlSyncMeta, *args, **kwargs)
+    base =  sqlalchemy.orm.declarative_base(cls = cls, metaclass = SqlSyncMeta, *args, **kwargs)
     base.registry = registry or registry_class()
     return base
 

--- a/entanglement/sql/internal.py
+++ b/entanglement/sql/internal.py
@@ -17,7 +17,7 @@ from ..network import logger
 from ..util import get_or_create
 from sqlalchemy import inspect
 from ..javascript_schema import javascript_registry
-
+from sqlalchemy.orm import with_polymorphic
 
 class _SqlMetaRegistry(SyncRegistry):
 
@@ -131,8 +131,8 @@ class _SqlMetaRegistry(SyncRegistry):
                     if c is base.SyncOwner or issubclass(c, base.SyncOwner): continue
                     if self.yield_between_classes: await asyncio.sleep(0)
                     if not session.is_active: session.rollback()
-                    to_sync = session.query(c).with_polymorphic('*') \
-                                              .outerjoin(base.SyncOwner).filter(c.sync_serial > obj.serial, owner_condition).all()
+                    poly = with_polymorphic(c, '*')
+                    to_sync = session.query(poly).outerjoin(base.SyncOwner).filter(c.sync_serial > obj.serial, owner_condition).all()
                 except:
                     logger.exception("Failed finding objects to send {} from  {}".format(sender, c.__name__))
                     raise

--- a/entanglement/sql/internal.py
+++ b/entanglement/sql/internal.py
@@ -206,7 +206,7 @@ def populate_owner_from_msg(msg, obj, session):
     if not owner: owner = getattr(obj, '_sync_owner', None)
     if owner is None:
         raise interface.SyncBadEncodingError("Owner not specified")
-    obj.sync_owner = session.query(base.SyncOwner).get(owner)
+    obj.sync_owner = session.get(base.SyncOwner, owner)
     if not obj.sync_owner:
         raise SyncBadEncodingError("You must synchronize the sync_owner, then drain before synchronizing IHave", msg = msg)
     session.expunge(obj.sync_owner)

--- a/entanglement/sql/upgrader.py
+++ b/entanglement/sql/upgrader.py
@@ -21,14 +21,14 @@ Upgrade the database to the latest version.  If version_table is present in the 
     conf = config.Config()
     conf.set_main_option('script_location', script_location)
     conf.engine = engine
-    reflection_meta = MetaData(bind = engine) # Used to check for table presence
+    reflection_meta = MetaData() # Used to check for table presence
     try:
-        Table(version_table, reflection_meta, autoload = True)
+        Table(version_table, reflection_meta, autoload_with = engine)
         #If no exception, version_table exists.
     except NoSuchTableError:
         if user_table:
             try:
-                Table(user_table, reflection_meta, autoload = True)
+                Table(user_table, reflection_meta, autoload_with = engine)
                 #user table is present.
                 command.stamp(conf, user_table_version)
             except NoSuchTableError:

--- a/entanglement/util.py
+++ b/entanglement/util.py
@@ -140,7 +140,7 @@ def get_or_create(session, model, filter_by, defaults = {}):
     filter_by_set = set(filter_by.keys())
     if filter_by_set == primary_key_set:
         primary_key_values = tuple(map(lambda x: filter_by.get(x), primary_key))
-        inst = session.query(model).get(primary_key_values)
+        inst = session.get(model, primary_key_values)
     else: inst = session.query(model).filter_by(**filter_by).first()
     if inst: return inst
     d = filter_by.copy()

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -27,7 +27,7 @@ def test_layout(layout):
         layout.client.session.add(t)
         layout.client.session.commit()
         settle_loop(layout.server.manager.loop)
-        t2 = layout.server.session.query(Foo).get(t.id)
+        t2 = layout.server.session.get(Foo, t.id)
         assert t2.sync_serial == t.sync_serial
 
         

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -107,6 +107,7 @@ class TestGateway(SqlFixture, unittest.TestCase):
         self.base = Base
         self.manager_registry = manager_registry
         self.other_registries = [no_response_registry]
+        self.client = None
         super().__init__(*args, **kwargs)
 
     def setUp(self):
@@ -134,11 +135,10 @@ class TestGateway(SqlFixture, unittest.TestCase):
         self.client_session.manager = self.client
 
     def tearDown(self):
-        self.client.close()
-        del self.client
+        if self.client is not None:
+            self.client.close()
+            del self.client
         super().tearDown()
-
-
 
     def testGatewayFlood(self):
         "When a client creates an object it floods across to another client"

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -70,6 +70,8 @@ class TableBase(Base):
     __mapper_args__ = {
         'polymorphic_on': 'type',
         'polymorphic_identity': 'base'}
+    def __repr__(self):
+        return f'TableBase(id={self.id}, type={self.type})'
 
 class TableInherits(TableBase):
     __tablename__ = "inherits_table"
@@ -79,6 +81,8 @@ class TableInherits(TableBase):
     info = Column(String(30))
     info2 = Column(String(30))
     __mapper_args__ = {'polymorphic_identity': "inherits"}
+    def __repr__(self):
+        return f'TableInherits(id={self.id}, info={self.info}, info2={self.info2})'
 
 class TableError(Base):
     __tablename__ = 'error'

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -145,7 +145,7 @@ class TestGateway(SqlFixture, unittest.TestCase):
         session = self.client_session
         t = TableBase()
         session.add(t)
-        with wait_for_call(self.loop, self.base.registry, 'incoming_sync'):
+        with wait_for_call(self.loop, self.manager_registry, 'incoming_sync'):
             session.commit()
         t2 = self.manager.session.query(TableBase).all()
         self.assertEqual(t2[0].id, t.id)

--- a/tests/test_sql_features.py
+++ b/tests/test_sql_features.py
@@ -122,7 +122,7 @@ def test_foreign_key_sync(layout_module, order_fn, monkeypatch):
     layout = layout_module
     order_fn(monkeypatch)
     for le in layout.layout_entries:
-        le.engine.execute('pragma foreign_keys = on')
+        le.engine.raw_connection().execute('pragma foreign_keys = on')
         layout.disconnect_all()
     session = Base.registry.sessionmaker(bind = layout.server.engine)
     t1 = T1()

--- a/tests/test_sql_features.py
+++ b/tests/test_sql_features.py
@@ -143,7 +143,7 @@ def test_foreign_key_sync(layout_module, order_fn, monkeypatch):
     csession = layout.client.session
     found_missing = False
     for id in t3_ids:
-        t3 = csession.query(T3).get(id)
+        t3 = csession.get(T3, id)
         if order_fn == order_100:
             if t3 is None:
                 found_missing = True

--- a/tests/websocket/test_websocket.py
+++ b/tests/websocket/test_websocket.py
@@ -72,6 +72,8 @@ class TableTransition(TableInherits, SqlTransitionTrackerMixin):
 
 class TestPhase(Base):
 
+    __test__ = False
+
     __tablename__ = "test_phase"
 
     id = Column(GUID, primary_key = True,


### PR DESCRIPTION
This passes the test suite with sqlalchemy 1.4.46+ds1-1 (bookworm) and 2.0.31+ds1-1 (trixie).

One warning I didn't address:

```
================================================================================================= warnings summary ==================================================================================================
tests/test_entanglement.py::TestSynchronization::testReconnect
  /home/kdienes/project/entanglement/entanglement/network.py:181: RuntimeWarning: coroutine 'SyncDestinationBase.connected' was never awaited
    await dest.connected(self, protocol, bwprotocol = bwprotocol)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```

I haven't done any significant operational testing; just pytest.